### PR TITLE
Auto-resolve Fabric admin alias from signed-in user via preprovision hook

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -7,3 +7,7 @@ metadata:
   template: azd-tdd-issdata@1.0.0
 infra:
    provider: "bicep"
+hooks:
+  preprovision:
+    shell: pwsh
+    run: ./infra/hooks/preprovision.ps1

--- a/infra/hooks/preprovision.ps1
+++ b/infra/hooks/preprovision.ps1
@@ -1,0 +1,16 @@
+#!/usr/bin/env pwsh
+
+# Get the signed-in user's UPN (email alias) from Azure AD
+# This avoids needing to ask for manual input during deployment
+
+Write-Host "Retrieving signed-in user's UPN from Azure AD..."
+
+$userPrincipalName = az ad signed-in-user show --query userPrincipalName -o tsv
+
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($userPrincipalName)) {
+    Write-Error "Failed to retrieve signed-in user's UPN. Make sure you are logged in with 'az login'."
+    exit 1
+}
+
+Write-Host "Setting AZURE_ADMIN_ALIAS to: $userPrincipalName"
+azd env set AZURE_ADMIN_ALIAS $userPrincipalName

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -10,7 +10,7 @@ param environmentName string
 param location string
 
 @description('The Azure admin alias (admin@domain.onmicrosoft.com) to deploy the resources to')
-param adminalias string
+param azureadminalias string
 
 @description('Connections object for the Logic App.')
 
@@ -41,7 +41,7 @@ module resources './resources.bicep' = {
     evhubnamespace: 'evhub${resourceToken}'
     evhubname: 'evhub${resourceToken}'
     location: location
-    admin: adminalias
+    admin: azureadminalias
     sku: 'F2'
   }
 }


### PR DESCRIPTION
## Summary

The Fabric capacity resource requires an admin email (UPN) for `administration.members`, but `azd` only provides `AZURE_PRINCIPAL_ID` as a GUID. This change resolves the admin alias automatically without requiring manual input during deployment.

## Changes

- **Add preprovision hook** (`infra/hooks/preprovision.ps1`) — Queries Azure AD for the signed-in user's UPN via `az ad signed-in-user show` and stores it as `AZURE_ADMIN_ALIAS` in the azd environment.
- **Register hook in `azure.yaml`** — Runs the script automatically before every `azd provision` / `azd up`.
- **Rename `adminalias` → `azureadminalias` in `main.bicep`** — Clearer parameter naming that reflects the value's purpose.

## How it works

1. User runs `azd up`
2. The preprovision hook fires, calls `az ad signed-in-user show --query userPrincipalName`
3. The UPN (e.g. `user@domain.com`) is saved as `AZURE_ADMIN_ALIAS`
4. Bicep receives it via `main.parameters.json` → `azureadminalias` param → Fabric capacity admin